### PR TITLE
Chart template improvements

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -1,0 +1,3 @@
+en:
+  PLUGIN_IPCOUNT:
+    CHART_LABEL: Accumulated Visitor Count

--- a/templates/visitors.html.twig
+++ b/templates/visitors.html.twig
@@ -6,8 +6,8 @@
             {{ page.content | raw }}  {# any page content will be shown before the count data graphics #}
         </div>
 
-        <h3 id='allcount'>Cumulated Visitor Count: {{ counter() }}</h3>
-        <button id="showPrevMonth">< Month</button>
+        <h3 id='allcount'>{{ 'PLUGIN_IPCOUNT.CHART_LABEL'|t }}: {{ counter() }}</h3>
+        <button id="showPrevMonth">&lt; Month</button>
         <button id="showToday">Today</button>
         <canvas id="ipChart"></canvas>
     </article>


### PR DESCRIPTION
I was browsing your repo and noticed the word 'Cumulative' in the chart label and thought that sounded strange. I have to admit I'm not sure if it's actually incorrect, but my partner who is a communications professional says it should either be 'Accumulated' or 'Cumulative'. I don't know the difference.

I then realised this string should ideally be translatable, so added this functionality.

The other part of this PR is escaping the '<' symbol, as that is unsafe for HTML parsers even though it renders just fine in my Firefox.